### PR TITLE
Improve wild stack detection

### DIFF
--- a/assets/src/game/command/reelEffect/ReelEffect_SymbolFeatureCommand.ts
+++ b/assets/src/game/command/reelEffect/ReelEffect_SymbolFeatureCommand.ts
@@ -7,6 +7,7 @@ import { FreeGameOneRoundResult } from '../../../sgv3/vo/result/FreeGameOneRound
 import { TopUpGameOneRoundResult } from '../../../sgv3/vo/result/TopUpGameOneRoundResult';
 import { BalanceUtil } from 'src/sgv3/util/BalanceUtil';
 import { WAY_GameResult } from '../../../sgv3way/vo/result/WAY_GameResult';
+import { Logger } from '../../../core/utils/Logger';
 
 export class ReelEffect_SymbolFeatureCommand extends puremvc.SimpleCommand {
     public static readonly NAME = 'ReelEffect_SymbolFeatureCommand';
@@ -50,32 +51,16 @@ export class ReelEffect_SymbolFeatureCommand extends puremvc.SimpleCommand {
         switch (myGameScene) {
             case GameScene.Game_1:
                 const screenSymbol = this.gameDataProxy.curRoundResult?.screenSymbol;
-                const waysResult = (
-                    this.gameDataProxy.curRoundResult?.waysGameResult as WAY_GameResult
-                )?.waysResult;
-                const isWinning = (x: number, y: number): boolean => {
-                    if (!waysResult) return false;
-                    for (const result of waysResult) {
-                        if (result.screenHitData?.[x]?.[y]) {
-                            return true;
-                        }
-                    }
-                    return false;
-                };
 
                 if (screenSymbol) {
                     for (let i = 0; i < screenSymbol.length; i++) {
                         const col = screenSymbol[i];
                         let j = 0;
                         while (j < col.length) {
-                            if (col[j] === SymbolId.WILD && isWinning(i, j)) {
+                            if (col[j] === SymbolId.WILD) {
                                 const start = j;
                                 let stackLen = 0;
-                                while (
-                                    j < col.length &&
-                                    col[j] === SymbolId.WILD &&
-                                    isWinning(i, j)
-                                ) {
+                                while (j < col.length && col[j] === SymbolId.WILD) {
                                     stackLen++;
                                     j++;
                                 }
@@ -139,6 +124,13 @@ export class ReelEffect_SymbolFeatureCommand extends puremvc.SimpleCommand {
                 }
                 break;
         }
+        const wildFlagBoard = this.reelDataProxy.symbolFeature.map((col) =>
+            col.map((pos) => pos.wildFlag)
+        );
+        Logger.i(
+            '[ReelEffect_SymbolFeatureCommand] wildFlag board: ' +
+                JSON.stringify(wildFlagBoard)
+        );
     }
 
     // ======================== Get Set ========================


### PR DESCRIPTION
## Summary
- detect wild stacks without checking winning lines

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842af878d6c8333ae6b8960a9ffe74b