### PR TITLE
Modify freegame trigger

### DIFF
--- a/assets/config/mock/tasks/FreeGame_NoWin_SpinResponse.json
+++ b/assets/config/mock/tasks/FreeGame_NoWin_SpinResponse.json
@@ -1,0 +1,242 @@
+{
+  "name": "h5.spin",
+  "data": {
+    "balance": 2392502.144,
+    "spinResult": {
+      "playerTotalWin": 0,
+      "baseGameResult": {
+        "usedTableIndex": 1,
+        "screenSymbol": [
+          [
+            14,
+            5,
+            5
+          ],
+          [
+            4,
+            14,
+            3
+          ],
+          [
+            5,
+            0,
+            14
+          ],
+          [
+            6,
+            4,
+            4
+          ],
+          [
+            6,
+            3,
+            7
+          ]
+        ],
+        "baseGameTotalWin": 0,
+        "waysGameResult": {
+          "playerWin": 0,
+          "waysResult": []
+        },
+        "specialFeatureResult": [
+          {
+            "specialHitInfo": "noSpecialHit",
+            "specialOperations": [],
+            "specialScreenHitData": [
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ]
+            ],
+            "specialScreenWin": 0
+          },
+          {
+            "specialHitInfo": "noSpecialHit",
+            "specialOperations": [],
+            "specialScreenHitData": [
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ]
+            ],
+            "specialScreenWin": 0
+          },
+          {
+            "specialHitInfo": "noSpecialHit",
+            "specialOperations": [],
+            "specialScreenHitData": [
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ],
+              [
+                false,
+                false,
+                false
+              ]
+            ],
+            "specialScreenWin": 0
+          }
+        ],
+        "displayInfo": {
+          "displayMethod": [
+            [
+              false
+            ],
+            [
+              false
+            ],
+            [
+              false
+            ],
+            [
+              false
+            ],
+            [
+              false
+            ]
+          ],
+          "bigWinType": "normal_1",
+          "prizePredictionType": "NoPredictionType",
+          "fortuneLevelType": "level1",
+          "dampInfo": [
+            [
+              3,
+              6,
+              5,
+              6,
+              6
+            ],
+            [
+              4,
+              3,
+              3,
+              2,
+              6
+            ]
+          ],
+          "rngInfo": [
+            [
+              52,
+              9,
+              6,
+              40,
+              10
+            ]
+          ]
+        },
+        "extendInfoForbaseGameResult": {
+          "isPowerUp": false,
+          "ballCount": 0,
+          "ballTotalCredit": 0,
+          "ballScreenLabel": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ]
+          ],
+          "extendPlayerWin": 0,
+          "extendGameFeature": 0
+        }
+      },
+      "bigWinType": "normal_1",
+      "probabilityDetail": {
+        "randomNumberUsed": 6,
+        "randomDataUsed": [
+          10,
+          52,
+          9,
+          6,
+          40,
+          10
+        ]
+      }
+    },
+    "gameSeq": 234349031,
+    "ts": 1637650588320
+  },
+  "description": "無得分盤面",
+  "event": "h5.spinResponse",
+  "delay": 0,
+  "repeat": 1,
+  "duration": 0
+}

--- a/assets/config/mock/tasks/FreeGame_NoWin_SpinResponse.json.meta
+++ b/assets/config/mock/tasks/FreeGame_NoWin_SpinResponse.json.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.0.0",
+  "importer": "json",
+  "imported": true,
+  "uuid": "7390a0db-2363-4ce0-93f0-df27fa9ba459",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/src/sgv3/command/state/Game1EndCommand.ts
+++ b/assets/src/sgv3/command/state/Game1EndCommand.ts
@@ -5,6 +5,8 @@ import { TakeWinCommand } from '../balance/TakeWinCommand';
 import { StateCommand } from './StateCommand';
 import { NetworkProxy } from '../../../core/proxy/NetworkProxy';
 import { GameStateId } from '../../vo/data/GameStateId';
+import { SymbolId } from '../../vo/enum/Reel';
+import { BaseGameResult } from '../../vo/result/BaseGameResult';
 
 export class Game1EndCommand extends StateCommand {
     public static readonly NAME = StateMachineProxy.GAME1_EV_END;
@@ -16,7 +18,11 @@ export class Game1EndCommand extends StateCommand {
             this.gameDataProxy.spinEventData != undefined &&
             this.gameDataProxy.reStateResult?.gameStateId == GameStateId.WAIT_FOR_CLIENT
         ) {
-            this.changeState(StateMachineProxy.GAME1_FEATURESELECTION);
+            if (this.hasThreeC2()) {
+                this.changeState(StateMachineProxy.GAME2_INIT);
+            } else {
+                this.changeState(StateMachineProxy.GAME1_FEATURESELECTION);
+            }
             return;
         }
 
@@ -38,5 +44,21 @@ export class Game1EndCommand extends StateCommand {
             this._networkProxy = this.facade.retrieveProxy(NetworkProxy.NAME) as NetworkProxy;
         }
         return this._networkProxy;
+    }
+
+    private hasThreeC2(): boolean {
+        const result = this.gameDataProxy.spinEventData.baseGameResult as BaseGameResult;
+        let count = 0;
+        for (let x = 0; x < result.screenSymbol.length; x++) {
+            for (let y = 0; y < result.screenSymbol[x].length; y++) {
+                if (result.screenSymbol[x][y] === SymbolId.C2) {
+                    count++;
+                    if (count >= 3) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- add FreeGame_NoWin spin response task with three C2 symbols
- update `Game1EndCommand` to transition to Game2 when three C2 are present

## Testing
- `jq '.data.spinResult.baseGameResult.screenSymbol' assets/config/mock/tasks/FreeGame_NoWin_SpinResponse.json`


------
https://chatgpt.com/codex/tasks/task_e_6846a93dff988333b1442de40215807b