### PR TITLE
Update FreeGame flow for C2 trigger

### DIFF
--- a/assets/config/mock/tasks/FreeGame_NoWin_SpinResponse.json
+++ b/assets/config/mock/tasks/FreeGame_NoWin_SpinResponse.json
@@ -7,9 +7,9 @@
             "baseGameResult": {
                 "usedTableIndex": 0,
                 "screenSymbol": [
-                    [1, 1, 1],
-                    [1, 1, 1],
-                    [1, 1, 1],
+                    [14, 1, 1],
+                    [1, 14, 1],
+                    [1, 1, 14],
                     [7, 3, 5],
                     [2, 4, 6]
                 ],
@@ -20,15 +20,9 @@
                 },
                 "specialFeatureResult": [
                     {
-                        "specialHitInfo": "waitingForClient",
-                        "specialOperations": [
-                            "waitingForClient",
-                            "freeGame_03",
-                            "freeGame_02",
-                            "freeGame_01",
-                            "topUpGame_01"
-                        ],
-                        "jsonExtendData": "{\"ballCount\":9,\"ballTotalCredit\":0,\"ballScreenLabel\":[[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0]]}",
+                        "specialHitInfo": "noSpecialHit",
+                        "specialOperations": [],
+                        "jsonExtendData": null,
                         "specialScreenHitData": [
                             [false, false, false],
                             [false, false, false],
@@ -73,9 +67,9 @@
                         "playerWin": 0,
                         "usedTableIndex": 0,
                         "screenSymbol": [
-                            [1, 1, 1],
-                            [1, 1, 1],
-                            [1, 1, 1],
+                            [14, 1, 1],
+                            [1, 14, 1],
+                            [1, 1, 14],
                             [7, 3, 5],
                             [2, 4, 6]
                         ],

--- a/assets/src/sgv3/command/state/Game1EndCommand.ts
+++ b/assets/src/sgv3/command/state/Game1EndCommand.ts
@@ -5,6 +5,8 @@ import { TakeWinCommand } from '../balance/TakeWinCommand';
 import { StateCommand } from './StateCommand';
 import { NetworkProxy } from '../../../core/proxy/NetworkProxy';
 import { GameStateId } from '../../vo/data/GameStateId';
+import { BaseGameResult } from '../../vo/result/BaseGameResult';
+import { SymbolId } from '../../vo/enum/Reel';
 
 export class Game1EndCommand extends StateCommand {
     public static readonly NAME = StateMachineProxy.GAME1_EV_END;
@@ -17,6 +19,11 @@ export class Game1EndCommand extends StateCommand {
             this.gameDataProxy.reStateResult?.gameStateId == GameStateId.WAIT_FOR_CLIENT
         ) {
             this.changeState(StateMachineProxy.GAME1_FEATURESELECTION);
+            return;
+        }
+
+        if (this.hasThreeC2(this.gameDataProxy.curRoundResult as BaseGameResult)) {
+            this.changeState(StateMachineProxy.GAME2_TRANSITIONS);
             return;
         }
 
@@ -38,5 +45,20 @@ export class Game1EndCommand extends StateCommand {
             this._networkProxy = this.facade.retrieveProxy(NetworkProxy.NAME) as NetworkProxy;
         }
         return this._networkProxy;
+    }
+
+    private hasThreeC2(curRoundResult: BaseGameResult): boolean {
+        let count = 0;
+        for (let i = 0; i < curRoundResult.screenSymbol.length; i++) {
+            for (let j = 0; j < curRoundResult.screenSymbol[i].length; j++) {
+                if (curRoundResult.screenSymbol[i][j] == SymbolId.C2) {
+                    count++;
+                    if (count >= 3) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- modify mock spin response to show three `C2` symbols and remove feature selection trigger
- skip feature selection when three `C2` symbols appear and transition directly to Game2

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find name 'Buffer', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6846ac4ac23c8333a33f968de1c92863