### PR TITLE
Add stack wild logic to game2

### DIFF
--- a/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
+++ b/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
@@ -1,7 +1,13 @@
 import { StateMachineProxy } from '../../proxy/StateMachineProxy';
-import { ViewMediatorEvent } from '../../util/Constant';
+import { ViewMediatorEvent, ReelEvent } from '../../util/Constant';
+import { macro } from 'cc';
 import { GlobalTimer } from '../../util/GlobalTimer';
 import { FreeGameOneRoundResult } from '../../vo/result/FreeGameOneRoundResult';
+import { ReelDataProxy } from '../../proxy/ReelDataProxy';
+import { SymbolInfo } from '../../vo/info/SymbolInfo';
+import { SymbolId } from '../../vo/enum/Reel';
+import { ReelViewMediator } from '../../../game/mediator/ReelViewMediator';
+import { GAME_ReelView } from '../../../game/view/GAME_ReelView';
 import { StateCommand } from './StateCommand';
 
 export class Game2BeforeShowCommand extends StateCommand {
@@ -12,12 +18,49 @@ export class Game2BeforeShowCommand extends StateCommand {
     public execute(notification: puremvc.INotification): void {
         this.notifyWebControl();
 
-        this.clearTimerKey(); //避免timer沒有清除的問題
-        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy
-            .curRoundResult as FreeGameOneRoundResult;
+        this.clearTimerKey(); //避免 timer沒有清除的問題
+
+        if (!this.playStackWild()) {
+            this.afterStackWild();
+        }
+    }
+
+    private clearTimerKey() {
+        GlobalTimer.getInstance().removeTimer(this.timerKey);
+    }
+
+    private playStackWild(): boolean {
+        let infos: SymbolInfo[] = [];
+        if (this.reelDataProxy.symbolFeature) {
+            for (let x = 0; x < this.reelDataProxy.symbolFeature.length; x++) {
+                for (let y = 0; y < this.reelDataProxy.symbolFeature[x].length; y++) {
+                    if (this.reelDataProxy.symbolFeature[x][y].wildFlag > 0) {
+                        infos.push({ x: x, y: y, sid: SymbolId.WILD });
+                    }
+                }
+            }
+        }
+        if (infos.length > 0) {
+            this.sendNotification(ReelEvent.SHOW_STACK_WILD, infos);
+            GlobalTimer.getInstance()
+                .registerTimer(this.timerKey, 0.1, this.checkStackWildFinish, this, macro.REPEAT_FOREVER)
+                .start();
+            return true;
+        }
+        return false;
+    }
+
+    private checkStackWildFinish() {
+        if (!this.reelView.isSymbolPlaying()) {
+            GlobalTimer.getInstance().removeTimer(this.timerKey);
+            this.afterStackWild();
+        }
+    }
+
+    private afterStackWild() {
+        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy.curRoundResult as FreeGameOneRoundResult;
         let sceneData = this.gameDataProxy.getSceneDataByName(this.gameDataProxy.curScene);
 
-        //判斷fortuneLevel參數是否需要變動;
         if (
             this.gameDataProxy.lastFortuneLevel == null ||
             this.gameDataProxy.lastFortuneLevel != freeGameOneRoundResult.displayInfo.fortuneLevelType
@@ -47,7 +90,20 @@ export class Game2BeforeShowCommand extends StateCommand {
         }
     }
 
-    private clearTimerKey() {
-        GlobalTimer.getInstance().removeTimer(this.timerKey);
+    protected _reelDataProxy: ReelDataProxy;
+    protected get reelDataProxy(): ReelDataProxy {
+        if (!this._reelDataProxy) {
+            this._reelDataProxy = this.facade.retrieveProxy(ReelDataProxy.NAME) as ReelDataProxy;
+        }
+        return this._reelDataProxy;
+    }
+
+    protected _reelView: GAME_ReelView;
+    protected get reelView(): GAME_ReelView {
+        if (!this._reelView) {
+            const mediator = this.facade.retrieveMediator(ReelViewMediator.NAME) as ReelViewMediator;
+            this._reelView = mediator.getViewComponent() as GAME_ReelView;
+        }
+        return this._reelView;
     }
 }

--- a/assets/src/sgv3/command/state/Game2ShowWinCommand.ts
+++ b/assets/src/sgv3/command/state/Game2ShowWinCommand.ts
@@ -1,6 +1,7 @@
 import { StateMachineProxy } from '../../proxy/StateMachineProxy';
-import { WinEvent, ReelEvent, FreeGameEvent } from '../../util/Constant';
-import { FreeGameOneRoundResult } from '../../vo/result/FreeGameOneRoundResult';
+import { ReelEvent } from '../../util/Constant';
+import { GameScene } from '../../vo/data/GameScene';
+import { GlobalTimer } from '../../util/GlobalTimer';
 import { ScoringHandleCommand } from '../byGame/ScoringHandleCommand';
 import { StateCommand } from './StateCommand';
 
@@ -9,15 +10,37 @@ export class Game2ShowWinCommand extends StateCommand {
     public execute(notification: puremvc.INotification): void {
         this.notifyWebControl();
 
-        this.showView();
+        if (this.gameDataProxy.preScene === GameScene.Game_3) {
+            if (this.gameDataProxy.stateWinData.totalAmount() > 0) {
+                this.sendNotification(ReelEvent.SHOW_REELS_WIN, this.gameDataProxy.curWinData);
+            }
+            GlobalTimer.getInstance()
+                .registerTimer(
+                    'showWinToAfterShow',
+                    1.0,
+                    () => {
+                        GlobalTimer.getInstance().removeTimer('showWinToAfterShow');
+                        this.changeState(StateMachineProxy.GAME2_AFTERSHOW);
+                    },
+                    this
+                )
+                .start();
+        } else {
+            this.showView();
+        }
     }
 
     /** 通知show線 */
     protected showView() {
-        // 輪播贏分 Symbol
-        let winType = this.gameDataProxy.curRoundResult.displayInfo.winType;
-        if (winType > 0) {
-            this.sendNotification(ReelEvent.SHOW_ALL_REELS_WIN, this.gameDataProxy.curWinData);
+        if (this.gameDataProxy.stateWinData.totalAmount() > 0) {
+            if (this.gameDataProxy.afterFeatureGame) {
+                this.sendNotification(ReelEvent.SHOW_REELS_WIN, this.gameDataProxy.curWinData);
+                this.sendNotification(ScoringHandleCommand.NAME);
+            } else {
+                this.sendNotification(ReelEvent.SHOW_ALL_REELS_WIN, this.gameDataProxy.curWinData);
+            }
+        } else {
+            this.sendNotification(ScoringHandleCommand.NAME);
         }
     }
 }


### PR DESCRIPTION
## Summary
- play ShowStack before show in Game2 like Game1
- send PlayStackWin when showing win for Game2

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_684a4506234483338a481efb6a4356bb