### PR TITLE
Add stacked wild logic for Game2

### DIFF
--- a/assets/src/game/command/reelEffect/ReelEffect_SymbolFeatureCommand.ts
+++ b/assets/src/game/command/reelEffect/ReelEffect_SymbolFeatureCommand.ts
@@ -95,6 +95,42 @@ export class ReelEffect_SymbolFeatureCommand extends puremvc.SimpleCommand {
                 let game2TopUpData = this.gameDataProxy.curRoundResult as FreeGameOneRoundResult;
                 let extendInfo = game2TopUpData.extendInfoForFreeGameResult;
 
+                const screenSymbol2 = this.gameDataProxy.curRoundResult?.screenSymbol;
+                const waysResult2 = (this.gameDataProxy.curRoundResult?.waysGameResult as WAY_GameResult)?.waysResult;
+                const isWinning2 = (x: number, y: number): boolean => {
+                    if (!waysResult2) return false;
+                    for (const result of waysResult2) {
+                        if (result.screenHitData?.[x]?.[y]) {
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+
+                if (screenSymbol2) {
+                    for (let i = 0; i < screenSymbol2.length; i++) {
+                        const col = screenSymbol2[i];
+                        let j = 0;
+                        while (j < col.length) {
+                            if (col[j] === SymbolId.WILD && isWinning2(i, j)) {
+                                const start = j;
+                                let stackLen = 0;
+                                while (j < col.length && col[j] === SymbolId.WILD && isWinning2(i, j)) {
+                                    stackLen++;
+                                    j++;
+                                }
+                                this.reelDataProxy.symbolFeature[i][start].wildFlag = stackLen;
+                                for (let k = start + 1; k < start + stackLen; k++) {
+                                    this.reelDataProxy.symbolFeature[i][k].wildFlag = -1;
+                                }
+                            } else {
+                                this.reelDataProxy.symbolFeature[i][j].wildFlag = 0;
+                                j++;
+                            }
+                        }
+                    }
+                }
+
                 for (let i = 0; i < extendInfo.sideCreditBallScreenLabel.length; i++) {
                     for (let j = 0; j < extendInfo.sideCreditBallScreenLabel[i].length; j++) {
                         this.reelDataProxy.symbolFeature[i][j].creditCent = this.gameDataProxy.convertCredit2Cash(

--- a/assets/src/game/command/state/GAME_Game2BeforeShowCommand.ts
+++ b/assets/src/game/command/state/GAME_Game2BeforeShowCommand.ts
@@ -1,9 +1,12 @@
-import { _decorator } from 'cc';
+import { _decorator, macro } from 'cc';
 import { Game2BeforeShowCommand } from '../../../sgv3/command/state/Game2BeforeShowCommand';
 import { ReelDataProxy } from '../../../sgv3/proxy/ReelDataProxy';
 import { StateMachineProxy } from '../../../sgv3/proxy/StateMachineProxy';
-import { FreeGameEvent, ViewMediatorEvent } from '../../../sgv3/util/Constant';
+import { FreeGameEvent, ReelEvent, ViewMediatorEvent } from '../../../sgv3/util/Constant';
 import { GlobalTimer } from '../../../sgv3/util/GlobalTimer';
+import { Logger } from '../../../core/utils/Logger';
+import { SymbolInfo } from '../../../sgv3/vo/info/SymbolInfo';
+import { SymbolId } from '../../../sgv3/vo/enum/Reel';
 import { FreeGameOneRoundResult } from '../../../sgv3/vo/result/FreeGameOneRoundResult';
 const { ccclass } = _decorator;
 
@@ -12,41 +15,72 @@ export class GAME_Game2BeforeShowCommand extends Game2BeforeShowCommand {
     protected timerKey = 'game2BeforeShow';
 
     public execute(notification: puremvc.INotification): void {
-        let self = this;
+        Logger.i('[GAME_Game2BeforeShowCommand] execute');
+        this.notifyWebControl();
 
-        self.notifyWebControl();
+        this.GAME_clearTimerKey(); // 避免timer沒有清除的問題
 
-        self.GAME_clearTimerKey(); //避免timer沒有清除的問題
+        const startFlow = () => {
+            if (!this.playStackWild()) {
+                this.afterStackWild();
+            }
+        };
 
-        if (self.isBallScoreShow() || self.isWildShow()) {
-            self.sendNotification(FreeGameEvent.ON_SIDE_BALL_SCORE_SHOW, self.beforeShow.bind(self));
+        if (this.isBallScoreShow() || this.isWildShow()) {
+            this.sendNotification(FreeGameEvent.ON_SIDE_BALL_SCORE_SHOW, startFlow);
         } else {
-            self.beforeShow();
+            startFlow();
         }
     }
 
-    private beforeShow() {
-        this.notifyWebControl();
+    private playStackWild(): boolean {
+        let infos: SymbolInfo[] = [];
+        let wildFlags: number[][] = [];
+        if (this.reelDataProxy.symbolFeature) {
+            for (let x = 0; x < this.reelDataProxy.symbolFeature.length; x++) {
+                wildFlags[x] = [];
+                for (let y = 0; y < this.reelDataProxy.symbolFeature[x].length; y++) {
+                    const flag = this.reelDataProxy.symbolFeature[x][y].wildFlag;
+                    wildFlags[x][y] = flag;
+                    if (flag > 0) {
+                        infos.push({ x: x, y: y, sid: SymbolId.WILD });
+                    }
+                }
+            }
+        }
 
-        this.GAME_clearTimerKey();
+        Logger.i(`[Game2] wildFlag = ${JSON.stringify(wildFlags)}`);
 
-        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy
-            .curRoundResult as FreeGameOneRoundResult;
+        if (infos.length > 0) {
+            this.sendNotification(ReelEvent.SHOW_STACK_WILD, infos);
+            GlobalTimer.getInstance()
+                .registerTimer(this.timerKey, 0.1, this.checkStackWildFinish, this, macro.REPEAT_FOREVER)
+                .start();
+            return true;
+        }
+        return false;
+    }
+
+    private checkStackWildFinish() {
+        if (!this.reelView.isSymbolPlaying()) {
+            GlobalTimer.getInstance().removeTimer(this.timerKey);
+            this.afterStackWild();
+        }
+    }
+
+    private afterStackWild() {
+        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy.curRoundResult as FreeGameOneRoundResult;
         let sceneData = this.gameDataProxy.getSceneDataByName(this.gameDataProxy.curScene);
 
-        //判斷fortuneLevel參數是否需要變動;
         if (
             this.gameDataProxy.lastFortuneLevel == null ||
             this.gameDataProxy.lastFortuneLevel != freeGameOneRoundResult.displayInfo.fortuneLevelType
         ) {
             this.gameDataProxy.lastFortuneLevel = freeGameOneRoundResult.displayInfo.fortuneLevelType;
-            this.sendNotification(
-                ViewMediatorEvent.FORTUNE_LEVEL_CHANGE,
-                freeGameOneRoundResult.displayInfo.fortuneLevelType
-            );
+            this.sendNotification(ViewMediatorEvent.FORTUNE_LEVEL_CHANGE, freeGameOneRoundResult.displayInfo.fortuneLevelType);
         }
 
-        if (this.gameDataProxy.curWinData.totalAmount() > 0) {
+        if (freeGameOneRoundResult.playerWin > 0) {
             this.changeState(StateMachineProxy.GAME2_SHOWWIN);
         } else {
             let stayTime = sceneData.noWinStayTime;

--- a/assets/src/game/command/state/GAME_Game2BeforeShowCommand.ts
+++ b/assets/src/game/command/state/GAME_Game2BeforeShowCommand.ts
@@ -136,4 +136,13 @@ export class GAME_Game2BeforeShowCommand extends Game2BeforeShowCommand {
         }
         return this._reelDataProxy;
     }
+
+    protected _reelView: GAME_ReelView;
+    protected get reelView(): GAME_ReelView {
+        if (!this._reelView) {
+            const mediator = this.facade.retrieveMediator(ReelViewMediator.NAME) as ReelViewMediator;
+            this._reelView = mediator.getViewComponent() as GAME_ReelView;
+        }
+        return this._reelView;
+    }
 }

--- a/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
+++ b/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
@@ -1,6 +1,7 @@
 import { StateMachineProxy } from '../../proxy/StateMachineProxy';
 import { macro } from 'cc';
 import { ReelEvent, ViewMediatorEvent } from '../../util/Constant';
+import { Logger } from '../../../core/utils/Logger';
 import { ReelDataProxy } from '../../proxy/ReelDataProxy';
 import { SymbolInfo } from '../../vo/info/SymbolInfo';
 import { SymbolId } from '../../vo/enum/Reel';
@@ -31,15 +32,22 @@ export class Game2BeforeShowCommand extends StateCommand {
 
     private playStackWild(): boolean {
         let infos: SymbolInfo[] = [];
+        let wildFlags: number[][] = [];
         if (this.reelDataProxy.symbolFeature) {
             for (let x = 0; x < this.reelDataProxy.symbolFeature.length; x++) {
+                wildFlags[x] = [];
                 for (let y = 0; y < this.reelDataProxy.symbolFeature[x].length; y++) {
-                    if (this.reelDataProxy.symbolFeature[x][y].wildFlag > 0) {
+                    const flag = this.reelDataProxy.symbolFeature[x][y].wildFlag;
+                    wildFlags[x][y] = flag;
+                    if (flag > 0) {
                         infos.push({ x: x, y: y, sid: SymbolId.WILD });
                     }
                 }
             }
         }
+
+        Logger.d(`[Game2] wildFlag = ${JSON.stringify(wildFlags)}`);
+
         if (infos.length > 0) {
             this.sendNotification(ReelEvent.SHOW_STACK_WILD, infos);
             GlobalTimer.getInstance()

--- a/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
+++ b/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
@@ -1,6 +1,12 @@
 import { StateMachineProxy } from '../../proxy/StateMachineProxy';
-import { ViewMediatorEvent } from '../../util/Constant';
+import { macro } from 'cc';
+import { ReelEvent, ViewMediatorEvent } from '../../util/Constant';
+import { ReelDataProxy } from '../../proxy/ReelDataProxy';
+import { SymbolInfo } from '../../vo/info/SymbolInfo';
+import { SymbolId } from '../../vo/enum/Reel';
 import { GlobalTimer } from '../../util/GlobalTimer';
+import { ReelViewMediator } from '../../../game/mediator/ReelViewMediator';
+import { GAME_ReelView } from '../../../game/view/GAME_ReelView';
 import { FreeGameOneRoundResult } from '../../vo/result/FreeGameOneRoundResult';
 import { StateCommand } from './StateCommand';
 
@@ -13,20 +19,54 @@ export class Game2BeforeShowCommand extends StateCommand {
         this.notifyWebControl();
 
         this.clearTimerKey(); //避免timer沒有清除的問題
-        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy
-            .curRoundResult as FreeGameOneRoundResult;
+
+        if (!this.playStackWild()) {
+            this.afterStackWild();
+        }
+    }
+
+    private clearTimerKey() {
+        GlobalTimer.getInstance().removeTimer(this.timerKey);
+    }
+
+    private playStackWild(): boolean {
+        let infos: SymbolInfo[] = [];
+        if (this.reelDataProxy.symbolFeature) {
+            for (let x = 0; x < this.reelDataProxy.symbolFeature.length; x++) {
+                for (let y = 0; y < this.reelDataProxy.symbolFeature[x].length; y++) {
+                    if (this.reelDataProxy.symbolFeature[x][y].wildFlag > 0) {
+                        infos.push({ x: x, y: y, sid: SymbolId.WILD });
+                    }
+                }
+            }
+        }
+        if (infos.length > 0) {
+            this.sendNotification(ReelEvent.SHOW_STACK_WILD, infos);
+            GlobalTimer.getInstance()
+                .registerTimer(this.timerKey, 0.1, this.checkStackWildFinish, this, macro.REPEAT_FOREVER)
+                .start();
+            return true;
+        }
+        return false;
+    }
+
+    private checkStackWildFinish() {
+        if (!this.reelView.isSymbolPlaying()) {
+            GlobalTimer.getInstance().removeTimer(this.timerKey);
+            this.afterStackWild();
+        }
+    }
+
+    private afterStackWild() {
+        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy.curRoundResult as FreeGameOneRoundResult;
         let sceneData = this.gameDataProxy.getSceneDataByName(this.gameDataProxy.curScene);
 
-        //判斷fortuneLevel參數是否需要變動;
         if (
             this.gameDataProxy.lastFortuneLevel == null ||
             this.gameDataProxy.lastFortuneLevel != freeGameOneRoundResult.displayInfo.fortuneLevelType
         ) {
             this.gameDataProxy.lastFortuneLevel = freeGameOneRoundResult.displayInfo.fortuneLevelType;
-            this.sendNotification(
-                ViewMediatorEvent.FORTUNE_LEVEL_CHANGE,
-                freeGameOneRoundResult.displayInfo.fortuneLevelType
-            );
+            this.sendNotification(ViewMediatorEvent.FORTUNE_LEVEL_CHANGE, freeGameOneRoundResult.displayInfo.fortuneLevelType);
         }
 
         if (freeGameOneRoundResult.playerWin > 0) {
@@ -47,7 +87,20 @@ export class Game2BeforeShowCommand extends StateCommand {
         }
     }
 
-    private clearTimerKey() {
-        GlobalTimer.getInstance().removeTimer(this.timerKey);
+    protected _reelDataProxy: ReelDataProxy;
+    protected get reelDataProxy(): ReelDataProxy {
+        if (!this._reelDataProxy) {
+            this._reelDataProxy = this.facade.retrieveProxy(ReelDataProxy.NAME) as ReelDataProxy;
+        }
+        return this._reelDataProxy;
+    }
+
+    protected _reelView: GAME_ReelView;
+    protected get reelView(): GAME_ReelView {
+        if (!this._reelView) {
+            const mediator = this.facade.retrieveMediator(ReelViewMediator.NAME) as ReelViewMediator;
+            this._reelView = mediator.getViewComponent() as GAME_ReelView;
+        }
+        return this._reelView;
     }
 }

--- a/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
+++ b/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
@@ -17,6 +17,7 @@ export class Game2BeforeShowCommand extends StateCommand {
     protected timerKey = 'game2BeforeShow';
 
     public execute(notification: puremvc.INotification): void {
+        Logger.i('[Game2BeforeShowCommand] execute');
         this.notifyWebControl();
 
         this.clearTimerKey(); //避免timer沒有清除的問題
@@ -46,7 +47,7 @@ export class Game2BeforeShowCommand extends StateCommand {
             }
         }
 
-        Logger.d(`[Game2] wildFlag = ${JSON.stringify(wildFlags)}`);
+        Logger.i(`[Game2] wildFlag = ${JSON.stringify(wildFlags)}`);
 
         if (infos.length > 0) {
             this.sendNotification(ReelEvent.SHOW_STACK_WILD, infos);

--- a/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
+++ b/assets/src/sgv3/command/state/Game2BeforeShowCommand.ts
@@ -1,13 +1,6 @@
 import { StateMachineProxy } from '../../proxy/StateMachineProxy';
-import { macro } from 'cc';
-import { ReelEvent, ViewMediatorEvent } from '../../util/Constant';
-import { Logger } from '../../../core/utils/Logger';
-import { ReelDataProxy } from '../../proxy/ReelDataProxy';
-import { SymbolInfo } from '../../vo/info/SymbolInfo';
-import { SymbolId } from '../../vo/enum/Reel';
+import { ViewMediatorEvent } from '../../util/Constant';
 import { GlobalTimer } from '../../util/GlobalTimer';
-import { ReelViewMediator } from '../../../game/mediator/ReelViewMediator';
-import { GAME_ReelView } from '../../../game/view/GAME_ReelView';
 import { FreeGameOneRoundResult } from '../../vo/result/FreeGameOneRoundResult';
 import { StateCommand } from './StateCommand';
 
@@ -17,65 +10,23 @@ export class Game2BeforeShowCommand extends StateCommand {
     protected timerKey = 'game2BeforeShow';
 
     public execute(notification: puremvc.INotification): void {
-        Logger.i('[Game2BeforeShowCommand] execute');
         this.notifyWebControl();
 
         this.clearTimerKey(); //避免timer沒有清除的問題
-
-        if (!this.playStackWild()) {
-            this.afterStackWild();
-        }
-    }
-
-    private clearTimerKey() {
-        GlobalTimer.getInstance().removeTimer(this.timerKey);
-    }
-
-    private playStackWild(): boolean {
-        let infos: SymbolInfo[] = [];
-        let wildFlags: number[][] = [];
-        if (this.reelDataProxy.symbolFeature) {
-            for (let x = 0; x < this.reelDataProxy.symbolFeature.length; x++) {
-                wildFlags[x] = [];
-                for (let y = 0; y < this.reelDataProxy.symbolFeature[x].length; y++) {
-                    const flag = this.reelDataProxy.symbolFeature[x][y].wildFlag;
-                    wildFlags[x][y] = flag;
-                    if (flag > 0) {
-                        infos.push({ x: x, y: y, sid: SymbolId.WILD });
-                    }
-                }
-            }
-        }
-
-        Logger.i(`[Game2] wildFlag = ${JSON.stringify(wildFlags)}`);
-
-        if (infos.length > 0) {
-            this.sendNotification(ReelEvent.SHOW_STACK_WILD, infos);
-            GlobalTimer.getInstance()
-                .registerTimer(this.timerKey, 0.1, this.checkStackWildFinish, this, macro.REPEAT_FOREVER)
-                .start();
-            return true;
-        }
-        return false;
-    }
-
-    private checkStackWildFinish() {
-        if (!this.reelView.isSymbolPlaying()) {
-            GlobalTimer.getInstance().removeTimer(this.timerKey);
-            this.afterStackWild();
-        }
-    }
-
-    private afterStackWild() {
-        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy.curRoundResult as FreeGameOneRoundResult;
+        let freeGameOneRoundResult: FreeGameOneRoundResult = this.gameDataProxy
+            .curRoundResult as FreeGameOneRoundResult;
         let sceneData = this.gameDataProxy.getSceneDataByName(this.gameDataProxy.curScene);
 
+        //判斷fortuneLevel參數是否需要變動;
         if (
             this.gameDataProxy.lastFortuneLevel == null ||
             this.gameDataProxy.lastFortuneLevel != freeGameOneRoundResult.displayInfo.fortuneLevelType
         ) {
             this.gameDataProxy.lastFortuneLevel = freeGameOneRoundResult.displayInfo.fortuneLevelType;
-            this.sendNotification(ViewMediatorEvent.FORTUNE_LEVEL_CHANGE, freeGameOneRoundResult.displayInfo.fortuneLevelType);
+            this.sendNotification(
+                ViewMediatorEvent.FORTUNE_LEVEL_CHANGE,
+                freeGameOneRoundResult.displayInfo.fortuneLevelType
+            );
         }
 
         if (freeGameOneRoundResult.playerWin > 0) {
@@ -96,20 +47,7 @@ export class Game2BeforeShowCommand extends StateCommand {
         }
     }
 
-    protected _reelDataProxy: ReelDataProxy;
-    protected get reelDataProxy(): ReelDataProxy {
-        if (!this._reelDataProxy) {
-            this._reelDataProxy = this.facade.retrieveProxy(ReelDataProxy.NAME) as ReelDataProxy;
-        }
-        return this._reelDataProxy;
-    }
-
-    protected _reelView: GAME_ReelView;
-    protected get reelView(): GAME_ReelView {
-        if (!this._reelView) {
-            const mediator = this.facade.retrieveMediator(ReelViewMediator.NAME) as ReelViewMediator;
-            this._reelView = mediator.getViewComponent() as GAME_ReelView;
-        }
-        return this._reelView;
+    private clearTimerKey() {
+        GlobalTimer.getInstance().removeTimer(this.timerKey);
     }
 }


### PR DESCRIPTION
## Summary
- support stacked wild feature in Game2 beforeShow command
- compute wildFlag for Game2 reels like Game1

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a4a4a924883338c44bd0264754781