### PR TITLE
Update mystery symbol win animation

### DIFF
--- a/assets/art/source/cocos-animation/result-board/ResultBoard_In.anim
+++ b/assets/art/source/cocos-animation/result-board/ResultBoard_In.anim
@@ -167,16 +167,16 @@
     },
     "_channels": [
       {
-        "__id__": 16
+        "__id__": 15
       },
       {
-        "__id__": 18
+        "__id__": 17
       },
       {
-        "__id__": 20
+        "__id__": 19
       },
       {
-        "__id__": 22
+        "__id__": 21
       }
     ],
     "_nComponents": 3
@@ -184,20 +184,13 @@
   {
     "__type__": "cc.animation.TrackPath",
     "_paths": [
-      {
-        "__id__": 15
-      },
       "scale"
     ]
   },
   {
-    "__type__": "cc.animation.HierarchyPath",
-    "path": "Result_Num"
-  },
-  {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 17
+      "__id__": 16
     }
   },
   {
@@ -257,7 +250,7 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 19
+      "__id__": 18
     }
   },
   {
@@ -317,7 +310,7 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 21
+      "__id__": 20
     }
   },
   {
@@ -377,7 +370,7 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 23
+      "__id__": 22
     }
   },
   {

--- a/assets/art/source/cocos-animation/result-board/ResultBoard_Out.anim
+++ b/assets/art/source/cocos-animation/result-board/ResultBoard_Out.anim
@@ -16,9 +16,6 @@
       },
       {
         "__id__": 13
-      },
-      {
-        "__id__": 24
       }
     ],
     "_exoticAnimation": null,
@@ -170,228 +167,16 @@
     },
     "_channels": [
       {
-        "__id__": 16
-      },
-      {
-        "__id__": 18
-      },
-      {
-        "__id__": 20
-      },
-      {
-        "__id__": 22
-      }
-    ],
-    "_nComponents": 3
-  },
-  {
-    "__type__": "cc.animation.TrackPath",
-    "_paths": [
-      {
         "__id__": 15
       },
-      "scale"
-    ]
-  },
-  {
-    "__type__": "cc.animation.HierarchyPath",
-    "path": "Result_Num"
-  },
-  {
-    "__type__": "cc.animation.Channel",
-    "_curve": {
-      "__id__": 17
-    }
-  },
-  {
-    "__type__": "cc.RealCurve",
-    "_times": [
-      0,
-      0.16666666666666666,
-      0.43333333333333335
-    ],
-    "_values": [
       {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 1,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
+        "__id__": 17
       },
       {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 1,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
+        "__id__": 19
       },
       {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 0,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      }
-    ],
-    "preExtrapolation": 1,
-    "postExtrapolation": 1
-  },
-  {
-    "__type__": "cc.animation.Channel",
-    "_curve": {
-      "__id__": 19
-    }
-  },
-  {
-    "__type__": "cc.RealCurve",
-    "_times": [
-      0,
-      0.16666666666666666,
-      0.43333333333333335
-    ],
-    "_values": [
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 1,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      },
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 1,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      },
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 0,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      }
-    ],
-    "preExtrapolation": 1,
-    "postExtrapolation": 1
-  },
-  {
-    "__type__": "cc.animation.Channel",
-    "_curve": {
-      "__id__": 21
-    }
-  },
-  {
-    "__type__": "cc.RealCurve",
-    "_times": [
-      0,
-      0.16666666666666666,
-      0.43333333333333335
-    ],
-    "_values": [
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 1,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      },
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 1,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      },
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 0,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      }
-    ],
-    "preExtrapolation": 1,
-    "postExtrapolation": 1
-  },
-  {
-    "__type__": "cc.animation.Channel",
-    "_curve": {
-      "__id__": 23
-    }
-  },
-  {
-    "__type__": "cc.RealCurve",
-    "_times": [],
-    "_values": [],
-    "preExtrapolation": 1,
-    "postExtrapolation": 1
-  },
-  {
-    "__type__": "cc.animation.VectorTrack",
-    "_binding": {
-      "__type__": "cc.animation.TrackBinding",
-      "path": {
-        "__id__": 25
-      }
-    },
-    "_channels": [
-      {
-        "__id__": 26
-      },
-      {
-        "__id__": 28
-      },
-      {
-        "__id__": 30
-      },
-      {
-        "__id__": 32
+        "__id__": 21
       }
     ],
     "_nComponents": 3
@@ -405,7 +190,7 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 27
+      "__id__": 16
     }
   },
   {
@@ -426,9 +211,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -440,9 +223,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -454,9 +235,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       }
     ],
     "preExtrapolation": 1,
@@ -465,7 +244,7 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 29
+      "__id__": 18
     }
   },
   {
@@ -486,9 +265,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -500,9 +277,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -514,9 +289,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       }
     ],
     "preExtrapolation": 1,
@@ -525,7 +298,7 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 31
+      "__id__": 20
     }
   },
   {
@@ -546,9 +319,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -560,9 +331,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -574,9 +343,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       }
     ],
     "preExtrapolation": 1,
@@ -585,7 +352,7 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 33
+      "__id__": 22
     }
   },
   {

--- a/assets/art/source/cocos-animation/result-board/ResultBoard_Out.anim
+++ b/assets/art/source/cocos-animation/result-board/ResultBoard_Out.anim
@@ -16,6 +16,9 @@
       },
       {
         "__id__": 13
+      },
+      {
+        "__id__": 24
       }
     ],
     "_exoticAnimation": null,
@@ -151,9 +154,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       }
     ],
     "preExtrapolation": 1,
@@ -220,9 +221,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -234,9 +233,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -248,9 +245,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       }
     ],
     "preExtrapolation": 1,
@@ -280,9 +275,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -294,9 +287,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       },
       {
         "__type__": "cc.RealKeyframeValue",
@@ -308,9 +299,7 @@
         "leftTangent": 0,
         "leftTangentWeight": 1,
         "easingMethod": 0,
-        "__editorExtras__": {
-          "tangentMode": 0
-        }
+        "__editorExtras__": {}
       }
     ],
     "preExtrapolation": 1,
@@ -320,6 +309,103 @@
     "__type__": "cc.animation.Channel",
     "_curve": {
       "__id__": 21
+    }
+  },
+  {
+    "__type__": "cc.RealCurve",
+    "_times": [
+      0,
+      0.16666666666666666,
+      0.43333333333333335
+    ],
+    "_values": [
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 1,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {}
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 1,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {}
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 0,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {}
+      }
+    ],
+    "preExtrapolation": 1,
+    "postExtrapolation": 1
+  },
+  {
+    "__type__": "cc.animation.Channel",
+    "_curve": {
+      "__id__": 23
+    }
+  },
+  {
+    "__type__": "cc.RealCurve",
+    "_times": [],
+    "_values": [],
+    "preExtrapolation": 1,
+    "postExtrapolation": 1
+  },
+  {
+    "__type__": "cc.animation.VectorTrack",
+    "_binding": {
+      "__type__": "cc.animation.TrackBinding",
+      "path": {
+        "__id__": 25
+      }
+    },
+    "_channels": [
+      {
+        "__id__": 26
+      },
+      {
+        "__id__": 28
+      },
+      {
+        "__id__": 30
+      },
+      {
+        "__id__": 32
+      }
+    ],
+    "_nComponents": 3
+  },
+  {
+    "__type__": "cc.animation.TrackPath",
+    "_paths": [
+      "scale"
+    ]
+  },
+  {
+    "__type__": "cc.animation.Channel",
+    "_curve": {
+      "__id__": 27
     }
   },
   {
@@ -379,7 +465,127 @@
   {
     "__type__": "cc.animation.Channel",
     "_curve": {
-      "__id__": 23
+      "__id__": 29
+    }
+  },
+  {
+    "__type__": "cc.RealCurve",
+    "_times": [
+      0,
+      0.16666666666666666,
+      0.43333333333333335
+    ],
+    "_values": [
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 1,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {
+          "tangentMode": 0
+        }
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 1,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {
+          "tangentMode": 0
+        }
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 0,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {
+          "tangentMode": 0
+        }
+      }
+    ],
+    "preExtrapolation": 1,
+    "postExtrapolation": 1
+  },
+  {
+    "__type__": "cc.animation.Channel",
+    "_curve": {
+      "__id__": 31
+    }
+  },
+  {
+    "__type__": "cc.RealCurve",
+    "_times": [
+      0,
+      0.16666666666666666,
+      0.43333333333333335
+    ],
+    "_values": [
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 1,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {
+          "tangentMode": 0
+        }
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 1,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {
+          "tangentMode": 0
+        }
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 0,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {
+          "tangentMode": 0
+        }
+      }
+    ],
+    "preExtrapolation": 1,
+    "postExtrapolation": 1
+  },
+  {
+    "__type__": "cc.animation.Channel",
+    "_curve": {
+      "__id__": 33
     }
   },
   {

--- a/assets/prefabs/freegame/COM_ResultBoard.prefab
+++ b/assets/prefabs/freegame/COM_ResultBoard.prefab
@@ -420,8 +420,8 @@
     },
     "_lscale": {
       "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
+      "x": 0,
+      "y": 0,
       "z": 1
     },
     "_layer": 33554432,
@@ -441,7 +441,7 @@
       "__id__": 15
     },
     "_children": [],
-    "_active": false,
+    "_active": true,
     "_components": [
       {
         "__id__": 17
@@ -459,7 +459,7 @@
     "_lpos": {
       "__type__": "cc.Vec3",
       "x": 0,
-      "y": 120,
+      "y": 0,
       "z": 0
     },
     "_lrot": {
@@ -497,8 +497,8 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 320,
-      "height": 50
+      "width": 397,
+      "height": 275
     },
     "_anchorPoint": {
       "__type__": "cc.Vec2",
@@ -564,7 +564,7 @@
     "__prefab": {
       "__id__": 22
     },
-    "spriteUrl": "db://assets/art/language/${i18n._language}/common/result-board/WinText_Total.png@f9941",
+    "spriteUrl": "db://assets/art/language/${i18n._language}/freegame/Free_ResultBoard_TotalWin.png@f9941",
     "_id": ""
   },
   {

--- a/assets/src/game/mediator/ReelViewMediator.ts
+++ b/assets/src/game/mediator/ReelViewMediator.ts
@@ -444,7 +444,18 @@ export class ReelViewMediator extends BaseReelViewMediator<GAME_ReelView> {
         let self = this;
         self.winData = WinData.concat();
         self.curIndex = -1;
-        self.reelView.createAnimSymbols(WinData.animationInfos);
+        const freeResult = this.gameDataProxy.curRoundResult as FreeGameOneRoundResult;
+        const mysterySymbol = freeResult?.extendInfoForFreeGameResult?.mysterySymbol;
+        const animInfos: SymbolInfo[] = [];
+        WinData.animationInfos.forEach((info: SymbolInfo) => {
+            const animInfo = { ...info };
+            if (animInfo.sid === SymbolId.MY && mysterySymbol !== undefined) {
+                this.reelView.removeAnimSymbol(animInfo);
+                animInfo.sid = mysterySymbol;
+            }
+            animInfos.push(animInfo);
+        });
+        self.reelView.createAnimSymbols(animInfos);
         this.view.setReelWinMask(true);
         this.playAllLoopWin();
         this.reelView.checkNextLoopWin = () => self.checkNextWin();
@@ -492,6 +503,8 @@ export class ReelViewMediator extends BaseReelViewMediator<GAME_ReelView> {
         if (self.winData.wayInfos[wayInfoIndex].symbolId < 0) {
             return;
         }
+        const freeResult = this.gameDataProxy.curRoundResult as FreeGameOneRoundResult;
+        const mysterySymbol = freeResult?.extendInfoForFreeGameResult?.mysterySymbol;
         let symbolWin = self.winData.wayInfos[wayInfoIndex].symbolWin;
         if (symbolWin > 0) {
             let scoreDisplay: string = self.gameDataProxy.isOmniChannel()
@@ -503,10 +516,14 @@ export class ReelViewMediator extends BaseReelViewMediator<GAME_ReelView> {
         for (let i in self.winData.wayInfos[wayInfoIndex].symbols) {
             let symbol: SymbolInfo = self.winData.wayInfos[wayInfoIndex].symbols[i];
             if (symbol.sid >= 0) {
+                let playSymbol = symbol;
+                if (symbol.sid == SymbolId.MY && mysterySymbol !== undefined) {
+                    playSymbol = { ...symbol, sid: mysterySymbol };
+                }
                 if (symbol.sid == SymbolId.WILD && !self.isPlayedWildScoring) {
                     self.isPlayedWildScoring = true;
                 }
-                this.reelView.showLoopWinSymbol(symbol, self.reelDataProxy.symbolFeature[symbol.x][symbol.y]);
+                this.reelView.showLoopWinSymbol(playSymbol, self.reelDataProxy.symbolFeature[symbol.x][symbol.y]);
             } else {
                 this.reelView.setAnimSymbolHide(symbol);
             }

--- a/assets/src/game/view/GAME_ReelView.ts
+++ b/assets/src/game/view/GAME_ReelView.ts
@@ -214,7 +214,12 @@ export class GAME_ReelView extends ReelView {
         if (symbolInfo.sid !== SymbolId.MY) {
             return;
         }
-        this.setAnimSymbolPlay(symbolInfo, featureInfo, SymbolPerformType.SHOW_MYSTERY);
+        this.setAnimSymbolPlay(
+            symbolInfo,
+            featureInfo,
+            SymbolPerformType.SHOW_MYSTERY,
+            () => this.removeAnimSymbol(symbolInfo)
+        );
         this.setDefaultSymbolPlay(symbolInfo, SymbolPerformType.HIDE);
     }
 
@@ -290,7 +295,8 @@ export class GAME_ReelView extends ReelView {
     protected setAnimSymbolPlay(
         symbolInfo: SymbolInfo,
         featureInfo: SymbolPosData,
-        type: SymbolPerformType = SymbolPerformType.SHOW
+        type: SymbolPerformType = SymbolPerformType.SHOW,
+        finishedCallback?: () => void
     ) {
         const self = this;
         let poolKey: number = symbolInfo.y * self.reelsList.length + symbolInfo.x;
@@ -299,7 +305,7 @@ export class GAME_ReelView extends ReelView {
         anim.node.setWorldPosition(self.getSymbolPosition(symbolInfo.x, symbolInfo.y));
         anim.setInfo(symbolInfo.sid, featureInfo);
         anim.node.active = true;
-        anim.play(type);
+        anim.play(type, finishedCallback ?? null);
     }
 
     protected setDefaultSymbolPlay(symbolInfo: SymbolInfo, type: SymbolPerformType) {

--- a/assets/src/game/view/GAME_ReelView.ts
+++ b/assets/src/game/view/GAME_ReelView.ts
@@ -161,6 +161,13 @@ export class GAME_ReelView extends ReelView {
         anim.setParent(self.animManager.node);
     }
 
+    public removeAnimSymbol(value: SymbolInfo) {
+        const poolKey: number = value.y * this.reelsList.length + value.x;
+        if (this.animManager.pool.has(poolKey)) {
+            this.animManager.putAnim(poolKey);
+        }
+    }
+
     public showAllWinSymbol(symbolInfo: SymbolInfo) {
         const self = this;
         self.setDefaultSymbolPlay(symbolInfo, SymbolPerformType.SHOW_ALL_WIN);


### PR DESCRIPTION
## Summary
- handle clearing mystery symbol effects before showing all wins
- use FreeGame result's `mysterySymbol` id when playing MY symbol animations
- expose `removeAnimSymbol` helper

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fd03485dc83339649bf6c33d1db6e