### PR TITLE
Implement spin-triggered free game transition

### DIFF
--- a/assets/src/game/mediator/TransitionViewMediator.ts
+++ b/assets/src/game/mediator/TransitionViewMediator.ts
@@ -58,8 +58,19 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
                 break;
             case StateWinEvent.ON_GAME2_TRANSITIONS:
                 if (notification.getBody() == true) {
+                    self.waitForSpin = false;
                     self.onTransitionToFree();
-                    self.waitForSpin = true;
+                    GlobalTimer.getInstance()
+                        .registerTimer(
+                            this.waitForSpinTimerKey,
+                            1,
+                            () => {
+                                GlobalTimer.getInstance().removeTimer(this.waitForSpinTimerKey);
+                                self.waitForSpin = true;
+                            },
+                            self
+                        )
+                        .start();
                 } else {
                     self.onHideStartBoard();
                 }
@@ -71,17 +82,7 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
                 if (self.waitForSpin) {
                     self.waitForSpin = false;
                     self.onHideStartBoard();
-                    GlobalTimer.getInstance()
-                        .registerTimer(
-                            this.waitForSpinTimerKey,
-                            1,
-                            () => {
-                                GlobalTimer.getInstance().removeTimer(this.waitForSpinTimerKey);
-                                self.startGame2Transition();
-                            },
-                            self
-                        )
-                        .start();
+                    self.startGame2Transition();
                 }
                 break;
         }

--- a/assets/src/game/mediator/TransitionViewMediator.ts
+++ b/assets/src/game/mediator/TransitionViewMediator.ts
@@ -22,6 +22,7 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
 
     public transitionView: GAME_TransitionView = null;
     private waitForSpin: boolean = false;
+    private readonly waitForSpinTimerKey = 'wait_for_spin_delay';
 
     constructor(name?: string, component?: any) {
         super(TransitionViewMediator.NAME, component);
@@ -70,7 +71,17 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
                 if (self.waitForSpin) {
                     self.waitForSpin = false;
                     self.onHideStartBoard();
-                    self.startGame2Transition();
+                    GlobalTimer.getInstance()
+                        .registerTimer(
+                            this.waitForSpinTimerKey,
+                            1,
+                            () => {
+                                GlobalTimer.getInstance().removeTimer(this.waitForSpinTimerKey);
+                                self.startGame2Transition();
+                            },
+                            self
+                        )
+                        .start();
                 }
                 break;
         }

--- a/assets/src/game/mediator/TransitionViewMediator.ts
+++ b/assets/src/game/mediator/TransitionViewMediator.ts
@@ -2,7 +2,16 @@ import { _decorator } from 'cc';
 import BaseMediator from '../../base/BaseMediator';
 import { Logger } from '../../core/utils/Logger';
 import { SceneManager } from '../../core/utils/SceneManager';
-import { StateWinEvent, ViewMediatorEvent } from '../../sgv3/util/Constant';
+import {
+    ScreenEvent,
+    StateWinEvent,
+    ViewMediatorEvent,
+    WebGameState
+} from '../../sgv3/util/Constant';
+import { StateMachineCommand } from '../../core/command/StateMachineCommand';
+import { StateMachineObject } from '../../core/proxy/CoreStateMachineProxy';
+import { StateMachineProxy } from '../../sgv3/proxy/StateMachineProxy';
+import { WebBridgeProxy } from '../../sgv3/proxy/WebBridgeProxy';
 import { GlobalTimer } from '../../sgv3/util/GlobalTimer';
 import { GAME_TransitionView } from '../view/GAME_TransitionView';
 const { ccclass } = _decorator;
@@ -12,6 +21,7 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
     public static readonly NAME: string = 'TransitionViewMediator';
 
     public transitionView: GAME_TransitionView = null;
+    private waitForSpin: boolean = false;
 
     constructor(name?: string, component?: any) {
         super(TransitionViewMediator.NAME, component);
@@ -28,7 +38,8 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
             SceneManager.EV_ORIENTATION_HORIZONTAL,
             StateWinEvent.ON_GAME2_TRANSITIONS,
             StateWinEvent.ON_GAME4_TRANSITIONS,
-            ViewMediatorEvent.CHANGE_DISPLAY_CONTAINER
+            ViewMediatorEvent.CHANGE_DISPLAY_CONTAINER,
+            ScreenEvent.ON_SPIN_DOWN
         ];
         return eventList;
     }
@@ -45,10 +56,22 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
                 self.onOrientationHorizontal();
                 break;
             case StateWinEvent.ON_GAME2_TRANSITIONS:
-                if (notification.getBody() == true) self.onTransitionToFree();
+                if (notification.getBody() == true) {
+                    self.onTransitionToFree();
+                    self.waitForSpin = true;
+                } else {
+                    self.onHideStartBoard();
+                }
                 break;
             case StateWinEvent.ON_GAME4_TRANSITIONS:
                 if (notification.getBody() == true) self.onTransitionBGEffect();
+                break;
+            case ScreenEvent.ON_SPIN_DOWN:
+                if (self.waitForSpin) {
+                    self.waitForSpin = false;
+                    self.onHideStartBoard();
+                    self.startGame2Transition();
+                }
                 break;
         }
     }
@@ -95,5 +118,25 @@ export class TransitionViewMediator extends BaseMediator<GAME_TransitionView> {
                 this
             )
             .start();
+    }
+
+    protected onHideStartBoard() {
+        this.transitionView.hideStartBoard?.();
+    }
+
+    protected startGame2Transition() {
+        this.sendNotification(StateMachineCommand.NAME, new StateMachineObject(StateMachineProxy.GAME2_INIT));
+
+        this.sendNotification(ViewMediatorEvent.LEAVE);
+        this.sendNotification(ViewMediatorEvent.ENTER);
+        this.webBridgeProxy.sendGameState(WebBridgeProxy.curScene, WebGameState.INIT);
+    }
+
+    private _webBridgeProxy: WebBridgeProxy;
+    protected get webBridgeProxy(): WebBridgeProxy {
+        if (!this._webBridgeProxy) {
+            this._webBridgeProxy = this.facade.retrieveProxy(WebBridgeProxy.NAME) as WebBridgeProxy;
+        }
+        return this._webBridgeProxy;
     }
 }

--- a/assets/src/game/view/GAME_TransitionView.ts
+++ b/assets/src/game/view/GAME_TransitionView.ts
@@ -45,6 +45,10 @@ export class GAME_TransitionView extends BaseView {
         this.Free_StartBoard?.play('Board_Show');
     }
 
+    public hideStartBoard(): void {
+        this.Free_StartBoard?.play('Board_Hide');
+    }
+
     public setNodeActivity(active: boolean) {
         this.node.active = active;
     }

--- a/assets/src/sgv3/command/viewMediator/ChangeSceneViewCommand.ts
+++ b/assets/src/sgv3/command/viewMediator/ChangeSceneViewCommand.ts
@@ -67,9 +67,7 @@ export class ChangeSceneViewCommand extends puremvc.SimpleCommand {
                     this.webBridgeProxy.setElementDisplayById('maxSpinIcon', 'none');
                     this.sendNotification(StateWinEvent.ON_GAME2_TRANSITIONS, true); //通知轉場動畫
                     this.sendNotification(WinEvent.FORCE_WIN_DISPOSE);
-                    GlobalTimer.getInstance()
-                        .registerTimer('Game2_TransitionBG', 5.5, this.Game2TransitionsBG, this)
-                        .start();
+                    // 等待玩家按下 SPIN，由 TransitionViewMediator 觸發後續流程
                     return;
                 }
                 break;


### PR DESCRIPTION
## Summary
- adjust Game2 transition flow to wait for player spin
- update TransitionViewMediator to handle spin down events and close start board
- add hideStartBoard API on GAME_TransitionView

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module 'cc')*

------
https://chatgpt.com/codex/tasks/task_e_684fdf9290888333ad018635cfa4a3de